### PR TITLE
fix: SELECT TOP N * parser bug - prevent * consumption as multiply operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .github
+/tmp

--- a/src/parser/sql_parser.rs
+++ b/src/parser/sql_parser.rs
@@ -315,8 +315,11 @@ impl Parser {
         let distinct = self.match_token(TokenType::Distinct);
 
         // TOP N (SQL Server style)
+        // Use parse_primary() instead of parse_expr() to prevent the parser
+        // from consuming `*` (SELECT all columns) as a multiplication operator.
+        // This correctly handles: TOP 5, TOP 100, TOP (expr), TOP (@var)
         let top = if self.match_token(TokenType::Top) {
-            Some(Box::new(self.parse_expr()?))
+            Some(Box::new(self.parse_primary()?))
         } else {
             None
         };

--- a/tests/test_dialects.rs
+++ b/tests/test_dialects.rs
@@ -1910,3 +1910,62 @@ fn test_complex_select_identity_all_dialects() {
         }
     }
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SELECT TOP N — Cross-Dialect (Issue #1)
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_top_tsql_to_postgres() {
+    // T-SQL TOP → Postgres LIMIT
+    assert_transpile(
+        "SELECT TOP 5 * FROM t",
+        "SELECT * FROM t LIMIT 5",
+        Dialect::Tsql,
+        Dialect::Postgres,
+    );
+}
+
+#[test]
+fn test_top_tsql_to_mysql() {
+    // T-SQL TOP → MySQL LIMIT
+    assert_transpile(
+        "SELECT TOP 10 id FROM t",
+        "SELECT id FROM t LIMIT 10",
+        Dialect::Tsql,
+        Dialect::Mysql,
+    );
+}
+
+#[test]
+fn test_top_tsql_star_to_duckdb() {
+    // The exact bug case: TOP N * should not confuse * with multiplication
+    assert_transpile(
+        "SELECT TOP 5 * FROM t",
+        "SELECT * FROM t LIMIT 5",
+        Dialect::Tsql,
+        Dialect::DuckDb,
+    );
+}
+
+#[test]
+fn test_limit_postgres_to_tsql() {
+    // Postgres LIMIT → T-SQL TOP (reverse direction)
+    assert_transpile(
+        "SELECT * FROM t LIMIT 10",
+        "SELECT TOP 10 * FROM t",
+        Dialect::Postgres,
+        Dialect::Tsql,
+    );
+}
+
+#[test]
+fn test_top_parenthesized_tsql_to_postgres() {
+    // Parenthesized TOP expr
+    assert_transpile(
+        "SELECT TOP (5) * FROM t",
+        "SELECT * FROM t LIMIT (5)",
+        Dialect::Tsql,
+        Dialect::Postgres,
+    );
+}

--- a/tests/test_transpile.rs
+++ b/tests/test_transpile.rs
@@ -1100,3 +1100,48 @@ fn test_serde_roundtrip() {
 fn test_identity_truncate() {
     validate_identity("TRUNCATE TABLE t");
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SELECT TOP N (T-SQL) — Issue #1
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_top_n_star_tsql_roundtrip() {
+    // Core bug: SELECT TOP 5 * was failing because * was consumed as multiply
+    validate_with_dialect(
+        "SELECT TOP 5 * FROM t",
+        "SELECT TOP 5 * FROM t",
+        Dialect::Tsql,
+        Dialect::Tsql,
+    );
+}
+
+#[test]
+fn test_top_n_columns_tsql_roundtrip() {
+    validate_with_dialect(
+        "SELECT TOP 10 id, name FROM t",
+        "SELECT TOP 10 id, name FROM t",
+        Dialect::Tsql,
+        Dialect::Tsql,
+    );
+}
+
+#[test]
+fn test_top_n_parenthesized_tsql_roundtrip() {
+    validate_with_dialect(
+        "SELECT TOP (5) * FROM t",
+        "SELECT TOP (5) * FROM t",
+        Dialect::Tsql,
+        Dialect::Tsql,
+    );
+}
+
+#[test]
+fn test_top_distinct_tsql_roundtrip() {
+    validate_with_dialect(
+        "SELECT DISTINCT TOP 3 id FROM t",
+        "SELECT DISTINCT TOP 3 id FROM t",
+        Dialect::Tsql,
+        Dialect::Tsql,
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1 — `SELECT TOP N * FROM t` fails to parse because the parser consumes `*` as a multiplication operator.

## Root Cause

In `parse_select_body()`, the TOP value was parsed with `parse_expr()`, which allows the full expression precedence chain including `parse_multiplication()`. For `SELECT TOP 5 * FROM t`, after consuming `TOP` and parsing `5`, the parser saw `*` and interpreted `5 *` as the start of a multiplication expression, consuming the `*` that should have been the SELECT wildcard.

## Fix

Replaced `parse_expr()` with `parse_primary()` for the TOP value. `parse_primary()` only consumes a single atomic expression (number, identifier, or parenthesized expression), which correctly:
- Stops at `*` without consuming it as multiply
- Handles `TOP 5`, `TOP 100` (bare numbers)
- Handles `TOP (5)`, `TOP (@var)`, `TOP (5 + 3)` (parenthesized — delegates to full `parse_expr()` inside parens)

## Tests Added (9 new tests)

**T-SQL roundtrip** (`test_transpile.rs`):
- `SELECT TOP 5 * FROM t` — the core bug case
- `SELECT TOP 10 id, name FROM t` — named columns
- `SELECT TOP (5) * FROM t` — parenthesized form
- `SELECT DISTINCT TOP 3 id FROM t` — with DISTINCT

**Cross-dialect** (`test_dialects.rs`):
- T-SQL to Postgres: TOP 5 to LIMIT 5
- T-SQL to MySQL: TOP 10 to LIMIT 10
- T-SQL to DuckDB: TOP 5 * to LIMIT 5 (exact bug repro)
- Postgres to T-SQL: LIMIT 10 to TOP 10 (reverse)
- Parenthesized TOP to LIMIT

## Validation

All tests pass: **0 failures** across the full suite (334 tests + 2 doctests).
