### PR TITLE
fix(parser): preserve T-SQL OFFSET/FETCH across parse→generate roundtrip (CR-010)

### DIFF
--- a/src/parser/sql_parser.rs
+++ b/src/parser/sql_parser.rs
@@ -472,12 +472,16 @@ impl Parser {
         };
 
         let offset = if self.match_token(TokenType::Offset) {
-            Some(self.parse_expr()?)
+            let expr = self.parse_expr()?;
+            // T-SQL / ANSI SQL:2008 form: OFFSET n ROWS [FETCH …].
+            // Consume the optional ROWS/ROW keyword so FETCH can match next.
+            let _ = self.match_token(TokenType::Rows) || self.match_keyword("ROW");
+            Some(expr)
         } else {
             None
         };
 
-        // FETCH FIRST|NEXT n ROWS ONLY (Oracle / ANSI SQL:2008)
+        // FETCH FIRST|NEXT n ROWS ONLY (Oracle / ANSI SQL:2008 / T-SQL)
         let fetch_first = if self.match_token(TokenType::Fetch) {
             // consume FIRST or NEXT
             let _ = self.match_token(TokenType::First) || self.match_token(TokenType::Next);

--- a/tests/test_dialects.rs
+++ b/tests/test_dialects.rs
@@ -1656,6 +1656,53 @@ fn test_tsql_identity() {
     }
 }
 
+// CR-010: T-SQL OFFSET/FETCH must survive parse→generate roundtrip.
+#[test]
+fn test_tsql_offset_fetch_roundtrip_preserved() {
+    let input = "SELECT * FROM t ORDER BY id OFFSET 10 ROWS FETCH NEXT 25 ROWS ONLY";
+    assert_identity(input, Dialect::Tsql);
+}
+
+#[test]
+fn test_tsql_offset_fetch_with_subquery_order_roundtrip() {
+    let input = "SELECT a, b FROM t ORDER BY (SELECT NULL) OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY";
+    assert_identity(input, Dialect::Tsql);
+}
+
+#[test]
+fn test_tsql_offset_only_no_fetch_roundtrip() {
+    // OFFSET without FETCH is valid T-SQL (skip n, return all remaining).
+    let input = "SELECT * FROM t ORDER BY id OFFSET 5 ROWS";
+    assert_identity(input, Dialect::Tsql);
+}
+
+#[test]
+fn test_pg_limit_offset_transpile_then_tsql_roundtrip() {
+    use sqlglot_rust::{generate, parse, transpile};
+    let transpiled = transpile(
+        "SELECT id, name FROM users ORDER BY id LIMIT 20 OFFSET 40",
+        Dialect::Postgres,
+        Dialect::Tsql,
+    )
+    .unwrap();
+    assert!(
+        transpiled.to_uppercase().contains("FETCH NEXT"),
+        "transpile lost FETCH: {transpiled}"
+    );
+    let stmt = parse(&transpiled, Dialect::Tsql).unwrap();
+    let regenerated = generate(&stmt, Dialect::Tsql);
+    assert!(
+        regenerated
+            .to_uppercase()
+            .contains("FETCH NEXT 20 ROWS ONLY"),
+        "roundtrip lost FETCH: {regenerated}"
+    );
+    assert!(
+        regenerated.to_uppercase().contains("OFFSET 40 ROWS"),
+        "roundtrip lost OFFSET: {regenerated}"
+    );
+}
+
 // ── Trino (from test_trino via Presto) ──
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes **CR-010 / PSQ-2420**: T-SQL `FETCH NEXT m ROWS ONLY` was silently dropped during parse → generate roundtrips, causing data over-exposure in the Secure Query Gateway whenever an ABAC policy was active on a `LIMIT/OFFSET` query.

## Root cause
The defect is in the **parser**, not the generator. After parsing `OFFSET <expr>`, the parser did not consume the trailing `ROWS`/`ROW` keyword. So for input like:

\`\`\`
ORDER BY col OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY
\`\`\`

the next \`match_token(Fetch)\` saw \`ROWS\` and returned \`false\`, leaving \`fetch_first = None\`. The generator already emits \`OFFSET n ROWS FETCH NEXT m ROWS ONLY\` correctly for T-SQL/Fabric when \`fetch_first\` is set, which is why direct transpile worked but re-parsing the transpiled SQL did not.

## Fix
Two-line change in \`src/parser/sql_parser.rs\`: after parsing the OFFSET expression, consume the optional \`ROWS\`/\`ROW\` keyword (ANSI SQL:2008 / T-SQL form).

## Tests
Added 4 tests in \`tests/test_dialects.rs\`:
- \`test_tsql_offset_fetch_roundtrip_preserved\`
- \`test_tsql_offset_fetch_with_subquery_order_roundtrip\`
- \`test_tsql_offset_only_no_fetch_roundtrip\` (regression guard — OFFSET without FETCH must NOT add FETCH)
- \`test_pg_limit_offset_transpile_then_tsql_roundtrip\` (end-to-end ABAC pipeline scenario)

All previously passing tests continue to pass (zero regressions across the full suite).

## Validation
- \`cargo test\` — all suites green
- \`cargo fmt --all\` clean
- \`cargo clippy\` — no new warnings on changed lines

Refs: PSQ-2420