### PR TITLE
fix(generator): emit ROWS keyword after OFFSET for Oracle (CR-011)

### DIFF
--- a/src/generator/sql_generator.rs
+++ b/src/generator/sql_generator.rs
@@ -393,7 +393,10 @@ impl Generator {
 
         if let Some(offset) = &sel.offset {
             self.sep();
-            if matches!(self.dialect, Some(Dialect::Tsql) | Some(Dialect::Fabric)) {
+            if matches!(
+                self.dialect,
+                Some(Dialect::Tsql) | Some(Dialect::Fabric) | Some(Dialect::Oracle)
+            ) {
                 self.write_keyword("OFFSET ");
                 self.gen_expr(offset);
                 self.write(" ");

--- a/tests/test_dialects.rs
+++ b/tests/test_dialects.rs
@@ -1554,6 +1554,40 @@ fn test_oracle_identity() {
     }
 }
 
+// CR-011: Oracle OFFSET must include ROWS keyword (ORA-02000 without it).
+#[test]
+fn test_oracle_offset_fetch_roundtrip() {
+    let input = "SELECT a, b FROM t ORDER BY a OFFSET 10 ROWS FETCH FIRST 25 ROWS ONLY";
+    assert_identity(input, Dialect::Oracle);
+}
+
+#[test]
+fn test_oracle_offset_only_rows_keyword() {
+    let input = "SELECT * FROM t ORDER BY id OFFSET 3 ROWS";
+    assert_identity(input, Dialect::Oracle);
+}
+
+#[test]
+fn test_pg_to_oracle_limit_offset() {
+    assert_transpile(
+        "SELECT id, name FROM users ORDER BY id LIMIT 20 OFFSET 5",
+        "SELECT id, name FROM users ORDER BY id OFFSET 5 ROWS FETCH FIRST 20 ROWS ONLY",
+        Dialect::Postgres,
+        Dialect::Oracle,
+    );
+}
+
+#[test]
+fn test_pg_to_oracle_limit_offset_no_order_by() {
+    // Oracle does not require ORDER BY with OFFSET/FETCH (unlike T-SQL).
+    assert_transpile(
+        "SELECT * FROM t LIMIT 10 OFFSET 5",
+        "SELECT * FROM t OFFSET 5 ROWS FETCH FIRST 10 ROWS ONLY",
+        Dialect::Postgres,
+        Dialect::Oracle,
+    );
+}
+
 // ── PostgreSQL (from test_postgres.py) ──
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes **CR-011 / PSQ-2422**: Oracle generator omitted the mandatory `ROWS` keyword after `OFFSET n`, causing `ORA-02000: missing ROWS keyword` on all OFFSET-FETCH pagination queries routed through the gateway.

## Root cause
The CR-010 fix (v0.9.36) added `ROWS` emission for `Tsql | Fabric` but did not include Oracle, which requires the same SQL:2008 syntax: `OFFSET n ROWS FETCH FIRST m ROWS ONLY`.

## Fix
One-line change in `src/generator/sql_generator.rs`: add `| Some(Dialect::Oracle)` to the match pattern.

## Tests added (`tests/test_dialects.rs`)
- `test_oracle_offset_fetch_roundtrip` — identity roundtrip
- `test_oracle_offset_only_rows_keyword` — OFFSET without FETCH
- `test_pg_to_oracle_limit_offset` — PG LIMIT/OFFSET → Oracle OFFSET/FETCH FIRST
- `test_pg_to_oracle_limit_offset_no_order_by` — confirms Oracle doesn't need ORDER BY guard

Full suite green (1058+ tests, 0 failures). No regressions.

Refs: PSQ-2422