### PR TITLE
fix(parser): close CR-012 benchmark-driven parser/tokenizer gaps

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -98,6 +98,16 @@ pub enum Statement {
     Merge(MergeStatement),
     /// Raw / passthrough expression (for expressions that don't fit a specific statement type)
     Expression(Expr),
+    /// Catch-all for statements that the parser accepts for round-tripping
+    /// but does not model in detail (e.g. `SET extra_float_digits = 0`,
+    /// `SHOW VARIABLES LIKE 'innodb%'`, `GO`, `DECLARE @x INT = 1`,
+    /// `COMMENT ON COLUMN t.c IS 'x'`, `CREATE OPERATOR FAMILY …`,
+    /// vendor-specific `ALTER TABLE … COMPACT 'major'`).
+    ///
+    /// The verb (`kind`) preserves the original keyword(s) so the generator
+    /// can emit a literal round-trip; `body` is the raw rest of the
+    /// statement up to the terminating semicolon/EOF.
+    Command(CommandStatement),
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -364,6 +374,17 @@ pub enum Expr {
         filter: Option<Box<Expr>>,
         /// OVER window specification for window functions
         over: Option<WindowSpec>,
+        /// Inline ORDER BY inside the argument list, or a trailing
+        /// WITHIN GROUP (ORDER BY …) clause. Both surface forms are
+        /// stored here; the generator picks the right emission based
+        /// on `within_group`.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        order_by: Vec<OrderByItem>,
+        /// True iff the ORDER BY originally came from a trailing
+        /// `WITHIN GROUP (ORDER BY …)` clause rather than an inline
+        /// `ORDER BY` inside the argument list.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        within_group: bool,
     },
     /// `expr BETWEEN low AND high`
     Between {
@@ -1482,6 +1503,10 @@ pub enum BinaryOperator {
     Arrow,
     /// `->>` JSON text access
     DoubleArrow,
+    /// `@>` PostgreSQL "contains" (arrays / jsonb / range)
+    AtArrow,
+    /// `<@` PostgreSQL "is contained by"
+    ArrowAt,
 }
 
 /// Unary operators.
@@ -1764,6 +1789,28 @@ pub struct UseStatement {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub comments: Vec<String>,
     pub name: String,
+}
+
+/// A raw-tail statement preserved verbatim for round-tripping.
+///
+/// Used for statements the parser accepts but does not model in detail —
+/// `SET`, `SHOW`, `GO`, `DECLARE`, `COMMENT ON …`, `ANALYZE`, `DESCRIBE`,
+/// `LOAD`, `EXPLAIN (FORMAT …)`, vendor-specific `ALTER TABLE` tails,
+/// `CREATE OPERATOR/AGGREGATE/SEQUENCE/…`, etc. The verb sequence is
+/// preserved in `kind` and the remainder of the statement (up to the next
+/// `;` or EOF) is captured in `body` exactly as it appeared in the input.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandStatement {
+    /// Comments attached to this statement.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
+    /// Leading verb(s), uppercased — e.g. "SET", "SHOW", "GO",
+    /// "DECLARE", "COMMENT ON", "ANALYZE", "DESCRIBE", "LOAD",
+    /// "CREATE OPERATOR", "ALTER TABLE", "REM".
+    pub kind: String,
+    /// Raw tail of the statement (everything after `kind`), reproduced
+    /// verbatim so round-tripping preserves the original wording.
+    pub body: String,
 }
 
 /// A DROP TABLE statement.
@@ -2070,12 +2117,16 @@ impl Expr {
                 distinct,
                 filter,
                 over,
+                order_by,
+                within_group,
             } => Expr::Function {
                 name,
                 args: args.into_iter().map(|a| a.transform(func)).collect(),
                 distinct,
                 filter: filter.map(|f| Box::new(f.transform(func))),
                 over,
+                order_by,
+                within_group,
             },
             Expr::Nested(inner) => Expr::Nested(Box::new(inner.transform(func))),
             Expr::Cast { expr, data_type } => Expr::Cast {

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -329,6 +329,8 @@ pub fn func(name: &str, args: Vec<Expr>) -> Expr {
         distinct: false,
         filter: None,
         over: None,
+        order_by: vec![],
+        within_group: false,
     }
 }
 
@@ -349,6 +351,8 @@ pub fn func_distinct(name: &str, args: Vec<Expr>) -> Expr {
         distinct: true,
         filter: None,
         over: None,
+        order_by: vec![],
+        within_group: false,
     }
 }
 

--- a/src/dialects/mod.rs
+++ b/src/dialects/mod.rs
@@ -762,6 +762,8 @@ fn transform_expr(expr: Expr, target: Dialect) -> Expr {
             distinct,
             filter,
             over,
+            order_by,
+            within_group,
         } => {
             let new_name = map_function_name(&name, target);
             let new_args: Vec<Expr> = args
@@ -774,6 +776,8 @@ fn transform_expr(expr: Expr, target: Dialect) -> Expr {
                 distinct,
                 filter: filter.map(|f| Box::new(transform_expr(*f, target))),
                 over,
+                order_by,
+                within_group,
             }
         }
         // Recurse into typed function child expressions, with special handling
@@ -856,6 +860,8 @@ fn transform_expr(expr: Expr, target: Dialect) -> Expr {
                     distinct: false,
                     filter: None,
                     over: None,
+                    order_by: vec![],
+                    within_group: false,
                 };
             }
 
@@ -1337,6 +1343,8 @@ fn transform_quotes(expr: Expr, target: Dialect) -> Expr {
             distinct,
             filter,
             over,
+            order_by,
+            within_group,
         } => Expr::Function {
             name,
             args: args
@@ -1346,6 +1354,8 @@ fn transform_quotes(expr: Expr, target: Dialect) -> Expr {
             distinct,
             filter: filter.map(|f| Box::new(transform_quotes(*f, target))),
             over,
+            order_by,
+            within_group,
         },
         Expr::TypedFunction { func, filter, over } => Expr::TypedFunction {
             func: func.transform_children(&|e| transform_quotes(e, target)),
@@ -1468,6 +1478,8 @@ fn try_transform_interval_arithmetic(
                 distinct: false,
                 filter: None,
                 over: None,
+                order_by: vec![],
+                within_group: false,
             });
         }
     }
@@ -1491,6 +1503,8 @@ fn try_transform_interval_arithmetic(
                     distinct: false,
                     filter: None,
                     over: None,
+                    order_by: vec![],
+                    within_group: false,
                 });
             }
         }

--- a/src/dialects/plugin.rs
+++ b/src/dialects/plugin.rs
@@ -633,6 +633,8 @@ fn transform_expr_plugin(expr: Expr, target: &DialectRef) -> Expr {
                         distinct: false,
                         filter: filter.map(|f| Box::new(transform_expr_plugin(*f, target))),
                         over,
+                        order_by: vec![],
+                        within_group: false,
                     };
                 }
             }
@@ -649,6 +651,8 @@ fn transform_expr_plugin(expr: Expr, target: &DialectRef) -> Expr {
             distinct,
             filter,
             over,
+            order_by,
+            within_group,
         } => {
             let new_name = target.map_function_name(&name);
             let new_args: Vec<Expr> = args
@@ -661,6 +665,8 @@ fn transform_expr_plugin(expr: Expr, target: &DialectRef) -> Expr {
                 distinct,
                 filter: filter.map(|f| Box::new(transform_expr_plugin(*f, target))),
                 over,
+                order_by,
+                within_group,
             }
         }
         Expr::Cast { expr, data_type } => Expr::Cast {

--- a/src/generator/sql_generator.rs
+++ b/src/generator/sql_generator.rs
@@ -251,6 +251,18 @@ impl Generator {
                 self.gen_merge(s);
             }
             Statement::Expression(e) => self.gen_expr(e),
+            Statement::Command(s) => {
+                self.gen_comments(&s.comments);
+                self.gen_command(s);
+            }
+        }
+    }
+
+    fn gen_command(&mut self, c: &crate::ast::CommandStatement) {
+        self.write(&c.kind);
+        if !c.body.is_empty() {
+            self.write(" ");
+            self.write(&c.body);
         }
     }
 
@@ -684,6 +696,28 @@ impl Generator {
         }
         if self.pretty {
             self.indent_down();
+        }
+    }
+
+    fn gen_order_by_items_inline(&mut self, items: &[OrderByItem]) {
+        for (i, item) in items.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.gen_expr(&item.expr);
+            if !item.ascending {
+                self.write(" ");
+                self.write_keyword("DESC");
+            }
+            if let Some(nulls_first) = item.nulls_first {
+                if nulls_first {
+                    self.write(" ");
+                    self.write_keyword("NULLS FIRST");
+                } else {
+                    self.write(" ");
+                    self.write_keyword("NULLS LAST");
+                }
+            }
         }
     }
 
@@ -1654,6 +1688,8 @@ impl Generator {
             BinaryOperator::ShiftRight => " >> ",
             BinaryOperator::Arrow => " -> ",
             BinaryOperator::DoubleArrow => " ->> ",
+            BinaryOperator::AtArrow => " @> ",
+            BinaryOperator::ArrowAt => " <@ ",
         }
     }
 
@@ -1778,6 +1814,8 @@ impl Generator {
                 distinct,
                 filter,
                 over,
+                order_by,
+                within_group,
             } => {
                 self.write(name);
                 self.write("(");
@@ -1785,7 +1823,21 @@ impl Generator {
                     self.write_keyword("DISTINCT ");
                 }
                 self.gen_expr_list(args);
+                // Aggregate ORDER BY embedded in the argument list (not WITHIN GROUP).
+                if !*within_group && !order_by.is_empty() {
+                    self.write(" ");
+                    self.write_keyword("ORDER BY ");
+                    self.gen_order_by_items_inline(order_by);
+                }
                 self.write(")");
+
+                // WITHIN GROUP (ORDER BY ...) — ordered-set aggregates.
+                if *within_group && !order_by.is_empty() {
+                    self.write(" ");
+                    self.write_keyword("WITHIN GROUP (ORDER BY ");
+                    self.gen_order_by_items_inline(order_by);
+                    self.write(")");
+                }
 
                 if let Some(filter_expr) = filter {
                     self.write(" ");

--- a/src/optimizer/annotate_types.rs
+++ b/src/optimizer/annotate_types.rs
@@ -677,7 +677,7 @@ fn infer_binary_op_type(
     use BinaryOperator::*;
     match op {
         // Comparison operators → Boolean
-        Eq | Neq | Lt | Gt | LtEq | GtEq => Some(DataType::Boolean),
+        Eq | Neq | Lt | Gt | LtEq | GtEq | AtArrow | ArrowAt => Some(DataType::Boolean),
 
         // Logical operators → Boolean
         And | Or | Xor => Some(DataType::Boolean),

--- a/src/optimizer/pushdown_predicates.rs
+++ b/src/optimizer/pushdown_predicates.rs
@@ -657,6 +657,8 @@ mod tests {
             distinct: false,
             filter: None,
             over: None,
+            order_by: vec![],
+            within_group: false,
         };
         assert!(!is_pushable(&expr));
     }
@@ -674,6 +676,8 @@ mod tests {
                 order_by: vec![],
                 frame: None,
             }),
+            order_by: vec![],
+            within_group: false,
         };
         assert!(!is_pushable(&expr));
     }

--- a/src/parser/sql_parser.rs
+++ b/src/parser/sql_parser.rs
@@ -158,6 +158,161 @@ impl Parser {
         }
     }
 
+    /// Reconstruct a single token's surface representation for raw command
+    /// preservation. String literals are wrapped in their original quotes;
+    /// identifiers may carry a quote_char from the tokenizer.
+    fn token_text(token: &Token) -> String {
+        match token.token_type {
+            TokenType::String => format!("'{}'", token.value.replace('\'', "''")),
+            TokenType::Identifier if token.quote_char != '\0' => {
+                let (l, r) = match token.quote_char {
+                    '[' => ('[', ']'),
+                    c => (c, c),
+                };
+                format!("{l}{}{r}", token.value)
+            }
+            _ => token.value.clone(),
+        }
+    }
+
+    /// Join a slice of tokens with whitespace tuned for SQL — no space
+    /// before `,` `)` `;` `.`, no space after `(` or `.`.
+    fn join_tokens_for_raw(tokens: &[Token]) -> String {
+        let mut out = String::new();
+        let mut prev_no_space_after = true; // suppress leading space
+        for t in tokens {
+            let no_space_before = matches!(
+                t.token_type,
+                TokenType::Comma
+                    | TokenType::RParen
+                    | TokenType::Semicolon
+                    | TokenType::Dot
+                    | TokenType::RBracket
+            );
+            if !out.is_empty() && !prev_no_space_after && !no_space_before {
+                out.push(' ');
+            }
+            out.push_str(&Self::token_text(t));
+            prev_no_space_after = matches!(
+                t.token_type,
+                TokenType::LParen | TokenType::Dot | TokenType::LBracket
+            );
+        }
+        out
+    }
+
+    /// Consume tokens up to (but not including) the next top-level `;` or EOF,
+    /// returning the raw text of the consumed tokens with whitespace
+    /// reconstructed by [`join_tokens_for_raw`]. Honors parenthesis depth so
+    /// embedded `;` inside `(...)` does not terminate the statement.
+    fn consume_raw_to_statement_end(&mut self) -> String {
+        let start = self.pos;
+        let mut depth: i32 = 0;
+        while self.pos < self.tokens.len() {
+            let tt = &self.tokens[self.pos].token_type;
+            match tt {
+                TokenType::Eof => break,
+                TokenType::Semicolon if depth == 0 => break,
+                TokenType::LParen | TokenType::LBracket => {
+                    depth += 1;
+                    self.pos += 1;
+                }
+                TokenType::RParen | TokenType::RBracket => {
+                    depth = (depth - 1).max(0);
+                    self.pos += 1;
+                }
+                _ => self.pos += 1,
+            }
+        }
+        Self::join_tokens_for_raw(&self.tokens[start..self.pos])
+    }
+
+    /// Helper for the dispatcher: consume one verb token (already known) and
+    /// then capture the entire tail as a [`CommandStatement`].
+    fn parse_command_kind(&mut self, kind: &str) -> Result<Statement> {
+        self.advance(); // consume the verb token
+        let body = self.consume_raw_to_statement_end();
+        Ok(Statement::Command(CommandStatement {
+            comments: vec![],
+            kind: kind.to_string(),
+            body,
+        }))
+    }
+
+    /// `COMMENT ON {TABLE|COLUMN|...} <name> IS '...'` — preserved as raw.
+    /// `COMMENT` can also appear inside `CREATE TABLE` column definitions and
+    /// in other positions; only the standalone DDL form lands here because
+    /// the dispatcher peeks at the *first* token.
+    fn parse_comment_on_command(&mut self) -> Result<Statement> {
+        // Look ahead for "COMMENT ON" — if not "ON", fall back to parser error
+        // (the COMMENT token would otherwise have been consumed inside an
+        // expression / column-def parser, not at statement boundary).
+        if self.peek_offset(1).map(|t| t.value.to_uppercase()) != Some("ON".to_string()) {
+            return Err(SqlglotError::UnexpectedToken {
+                token: self.peek().clone(),
+            });
+        }
+        self.advance(); // COMMENT
+        let body = self.consume_raw_to_statement_end();
+        Ok(Statement::Command(CommandStatement {
+            comments: vec![],
+            kind: "COMMENT".to_string(),
+            body,
+        }))
+    }
+
+    /// Returns `true` when the current Identifier token is a known
+    /// statement-starting verb that we preserve verbatim.
+    fn match_command_keyword(&self) -> bool {
+        let v = self.peek().value.to_uppercase();
+        matches!(
+            v.as_str(),
+            "GO" | "DECLARE"
+                | "LOAD"
+                | "REM"
+                | "REMARK"
+                | "RESET"
+                | "PRAGMA"
+                | "VACUUM"
+                | "REINDEX"
+                | "CALL"
+                | "LOCK"
+                | "UNLOCK"
+                | "CLUSTER"
+                | "REFRESH"
+                | "CHECKPOINT"
+                | "LISTEN"
+                | "NOTIFY"
+                | "PREPARE"
+                | "EXECUTE"
+                | "DEALLOCATE"
+                | "DISCARD"
+                | "COPY"
+                | "ATTACH"
+                | "DETACH"
+                | "COMMENT"
+        )
+    }
+
+    /// Variant of [`parse_command_kind`] for verbs that arrive as an
+    /// Identifier token (no dedicated TokenType).
+    fn parse_command_from_identifier(&mut self) -> Result<Statement> {
+        let verb = self.peek().value.to_uppercase();
+        self.advance();
+        let body = self.consume_raw_to_statement_end();
+        Ok(Statement::Command(CommandStatement {
+            comments: vec![],
+            kind: verb,
+            body,
+        }))
+    }
+
+    /// Look at the token `offset` positions ahead of the current one,
+    /// returning `None` if past EOF.
+    fn peek_offset(&self, offset: usize) -> Option<&Token> {
+        self.tokens.get(self.pos + offset)
+    }
+
     /// Helper to check if current token is an identifier or keyword that can serve as a name.
     fn is_name_token(&self) -> bool {
         matches!(
@@ -190,6 +345,14 @@ impl Parser {
                 | TokenType::Pivot
                 | TokenType::Unpivot
                 | TokenType::Sets
+                | TokenType::Range
+                | TokenType::Conflict
+                | TokenType::Unnest
+                | TokenType::Text
+                | TokenType::Show
+                | TokenType::Describe
+                | TokenType::Analyze
+                | TokenType::Index
         )
     }
 
@@ -291,15 +454,33 @@ impl Parser {
             TokenType::Update => self.parse_update().map(Statement::Update),
             TokenType::Delete => self.parse_delete().map(Statement::Delete),
             TokenType::Merge => self.parse_merge().map(Statement::Merge),
-            TokenType::Create => self.parse_create(),
+            TokenType::Create => self.parse_create_or_command(),
             TokenType::Drop => self.parse_drop(),
-            TokenType::Alter => self.parse_alter_table().map(Statement::AlterTable),
+            TokenType::Alter => self.parse_alter_or_command(),
             TokenType::Truncate => self.parse_truncate().map(Statement::Truncate),
             TokenType::Begin | TokenType::Commit | TokenType::Rollback | TokenType::Savepoint => {
                 self.parse_transaction().map(Statement::Transaction)
             }
             TokenType::Explain => self.parse_explain().map(Statement::Explain),
             TokenType::Use => self.parse_use().map(Statement::Use),
+            // Raw-tail command statements: SET / SHOW / DESCRIBE / ANALYZE
+            // (when standalone, not as part of EXPLAIN) / COMMENT ON ... .
+            // We preserve the verb plus the entire remainder up to `;` or EOF
+            // so the AST round-trips even though we don't model these in detail.
+            TokenType::Set => self.parse_command_kind("SET"),
+            TokenType::Show => self.parse_command_kind("SHOW"),
+            TokenType::Describe => self.parse_command_kind("DESCRIBE"),
+            TokenType::Analyze => self.parse_command_kind("ANALYZE"),
+            TokenType::Comment => self.parse_comment_on_command(),
+            TokenType::Grant => self.parse_command_kind("GRANT"),
+            TokenType::Revoke => self.parse_command_kind("REVOKE"),
+            // Vendor-specific verbs that tokenize as plain identifiers:
+            //   GO (T-SQL batch separator), DECLARE (T-SQL/PL-pgSQL),
+            //   LOAD (PG / MySQL extensions), REM / REMARK (SQL*Plus),
+            //   RESET / PRAGMA / VACUUM / REINDEX (PG / SQLite), CALL (PSM).
+            TokenType::Identifier if self.match_command_keyword() => {
+                self.parse_command_from_identifier()
+            }
             _ => Err(SqlglotError::UnexpectedToken {
                 token: self.peek().clone(),
             }),
@@ -2074,6 +2255,43 @@ impl Parser {
         }
     }
 
+    /// Try [`parse_alter_table`]; on failure, rewind and capture the entire
+    /// `ALTER …` statement verbatim as a [`Statement::Command`]. This covers
+    /// the long tail of vendor-specific ALTER forms — MySQL `ALTER TABLE …
+    /// CONVERT TO CHARACTER SET … COLLATE …`, Hive `ALTER TABLE … PARTITION
+    /// (…) COMPACT 'major'`, T-SQL `ALTER TABLE … WITH (…) CHECK CONSTRAINT
+    /// …`, etc. (Gap 5)
+    fn parse_alter_or_command(&mut self) -> Result<Statement> {
+        let saved = self.pos;
+        let saved_comments = self.pending_comments.clone();
+        match self.parse_alter_table() {
+            Ok(stmt) => Ok(Statement::AlterTable(stmt)),
+            Err(_) => {
+                self.pos = saved;
+                self.pending_comments = saved_comments;
+                self.parse_command_kind("ALTER")
+            }
+        }
+    }
+
+    /// Try [`parse_create`]; on failure, rewind and capture the entire
+    /// `CREATE …` statement verbatim as a [`Statement::Command`]. Also
+    /// handles the `CREATE TABLE t AS VALUES (…)` form (Gap 7) and rarer
+    /// `CREATE OPERATOR / AGGREGATE / SEQUENCE / FUNCTION / TEXT SEARCH
+    /// CONFIGURATION / …` (Gap 4).
+    fn parse_create_or_command(&mut self) -> Result<Statement> {
+        let saved = self.pos;
+        let saved_comments = self.pending_comments.clone();
+        match self.parse_create() {
+            Ok(stmt) => Ok(stmt),
+            Err(_) => {
+                self.pos = saved;
+                self.pending_comments = saved_comments;
+                self.parse_command_kind("CREATE")
+            }
+        }
+    }
+
     // ── TRUNCATE ────────────────────────────────────────────────────
 
     fn parse_truncate(&mut self) -> Result<TruncateStatement> {
@@ -2203,6 +2421,8 @@ impl Parser {
                 TokenType::Gt => Some(BinaryOperator::Gt),
                 TokenType::LtEq => Some(BinaryOperator::LtEq),
                 TokenType::GtEq => Some(BinaryOperator::GtEq),
+                TokenType::AtArrow => Some(BinaryOperator::AtArrow),
+                TokenType::ArrowAt => Some(BinaryOperator::ArrowAt),
                 _ => None,
             };
 
@@ -2536,6 +2756,8 @@ impl Parser {
                     args,
                     distinct,
                     filter,
+                    order_by,
+                    within_group,
                     ..
                 } => {
                     expr = Expr::Function {
@@ -2544,6 +2766,8 @@ impl Parser {
                         distinct,
                         filter,
                         over: Some(spec),
+                        order_by,
+                        within_group,
                     };
                 }
                 Expr::TypedFunction { func, filter, .. } => {
@@ -2569,6 +2793,8 @@ impl Parser {
                     args,
                     distinct,
                     over,
+                    order_by,
+                    within_group,
                     ..
                 } => {
                     expr = Expr::Function {
@@ -2577,6 +2803,8 @@ impl Parser {
                         distinct,
                         filter: Some(Box::new(filter_expr)),
                         over,
+                        order_by,
+                        within_group,
                     };
                 }
                 Expr::TypedFunction { func, over, .. } => {
@@ -2960,20 +3188,54 @@ impl Parser {
                     } else {
                         self.parse_expr_list()?
                     };
+
+                    // Optional aggregate ORDER BY inside arg list (Postgres / Spark):
+                    //   array_agg(x ORDER BY y DESC)
+                    //   string_agg(x, ',' ORDER BY y)
+                    let mut agg_order_by: Vec<OrderByItem> = vec![];
+                    if self.peek_type() == &TokenType::Order {
+                        self.advance();
+                        self.expect(TokenType::By)?;
+                        agg_order_by = self.parse_order_by_items()?;
+                    }
                     self.expect(TokenType::RParen)?;
 
-                    // Try to construct a typed function variant
-                    if let Some(typed) = Self::try_typed_function(&name, args.clone(), distinct) {
-                        Ok(typed)
-                    } else {
-                        Ok(Expr::Function {
-                            name,
-                            args,
-                            distinct,
-                            filter: None,
-                            over: None,
-                        })
+                    // Optional WITHIN GROUP (ORDER BY ...) — ordered-set aggregates
+                    //   percentile_cont(0.5) WITHIN GROUP (ORDER BY x)
+                    //   listagg(x, ',') WITHIN GROUP (ORDER BY x)
+                    let mut within_group = false;
+                    let mut wg_order_by: Vec<OrderByItem> = vec![];
+                    if self.check_keyword("WITHIN") {
+                        self.advance();
+                        self.expect_keyword("GROUP")?;
+                        self.expect(TokenType::LParen)?;
+                        self.expect(TokenType::Order)?;
+                        self.expect(TokenType::By)?;
+                        wg_order_by = self.parse_order_by_items()?;
+                        self.expect(TokenType::RParen)?;
+                        within_group = true;
                     }
+
+                    let final_order_by = if within_group { wg_order_by } else { agg_order_by };
+
+                    // Try to construct a typed function variant only when there are no
+                    // aggregate-specific clauses (otherwise we lose them).
+                    if final_order_by.is_empty()
+                        && !within_group
+                        && let Some(typed) = Self::try_typed_function(&name, args.clone(), distinct)
+                    {
+                        return Ok(typed);
+                    }
+
+                    Ok(Expr::Function {
+                        name,
+                        args,
+                        distinct,
+                        filter: None,
+                        over: None,
+                        order_by: final_order_by,
+                        within_group,
+                    })
                 }
                 // Qualified column: table.column or table.*
                 else if self.match_token(TokenType::Dot) {
@@ -4105,6 +4367,7 @@ fn attach_comments_to_statement(stmt: &mut Statement, comments: Vec<String>) {
         Statement::Explain(s) => s.comments = comments,
         Statement::Use(s) => s.comments = comments,
         Statement::Merge(s) => s.comments = comments,
+        Statement::Command(s) => s.comments = comments,
         // Transaction and Expression don't have comment fields
         Statement::Transaction(_) | Statement::Expression(_) => {}
     }

--- a/src/parser/sql_parser.rs
+++ b/src/parser/sql_parser.rs
@@ -403,6 +403,11 @@ impl Parser {
         self.expect(TokenType::Select)?;
 
         let distinct = self.match_token(TokenType::Distinct);
+        // SQL-standard `SELECT ALL` quantifier (§7.12). Equivalent to omitting
+        // the quantifier; consume it so it does not get mis-parsed as a column.
+        if !distinct {
+            let _ = self.match_token(TokenType::All);
+        }
 
         // TOP N (SQL Server style)
         // Use parse_primary() instead of parse_expr() to prevent the parser
@@ -1231,7 +1236,12 @@ impl Parser {
 
         let mut assignments = Vec::new();
         loop {
-            let col = self.expect_name()?;
+            // Accept qualified LHS like `alias.col` (Oracle, T-SQL idiom).
+            let mut col = self.expect_name()?;
+            while self.match_token(TokenType::Dot) {
+                col.push('.');
+                col.push_str(&self.expect_name()?);
+            }
             self.expect(TokenType::Eq)?;
             let val = self.parse_expr()?;
             assignments.push((col, val));

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -248,6 +248,10 @@ pub enum TokenType {
     HashArrow,       // #>
     HashDoubleArrow, // #>>
     AtSign,          // @
+    /// `@>` PostgreSQL "contains" (arrays / jsonb / range)
+    AtArrow,
+    /// `<@` PostgreSQL "is contained by"
+    ArrowAt,
     Scope,           // ::
 
     // ── Punctuation ────────────────────────────────────────────────

--- a/src/tokens/tokenizer.rs
+++ b/src/tokens/tokenizer.rs
@@ -1,6 +1,22 @@
 use crate::errors::{Result, SqlglotError};
 use crate::tokens::{Token, TokenType};
 
+/// Identifier-start predicate. Accepts ASCII `_` plus any Unicode letter,
+/// matching SQL:2003 §5.2 (PostgreSQL/MySQL/SQLite/Oracle/ClickHouse all
+/// accept Unicode letters in regular identifiers).
+#[inline]
+fn is_identifier_start(c: char) -> bool {
+    c == '_' || c.is_alphabetic()
+}
+
+/// Identifier-continue predicate. Includes Unicode alphanumerics, `_`, and `$`
+/// (MySQL/Oracle/SQL Server/SQLite all permit `$` inside identifiers after
+/// the first character).
+#[inline]
+fn is_identifier_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_alphanumeric()
+}
+
 /// SQL tokenizer that converts a SQL string into a stream of tokens.
 ///
 /// Tracks line and column numbers for error reporting. Supports:
@@ -344,7 +360,7 @@ impl Tokenizer {
             c if c.is_ascii_digit() => self.read_number(start, start_line, start_col, c),
 
             // ── Identifiers and keywords ────────────────────────────
-            c if c.is_ascii_alphabetic() || c == '_' => {
+            c if is_identifier_start(c) => {
                 self.read_identifier(start, start_line, start_col, c)
             }
 
@@ -479,7 +495,7 @@ impl Tokenizer {
         value.push(first);
         while self
             .peek()
-            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+            .is_some_and(is_identifier_continue)
         {
             value.push(self.advance().unwrap());
         }

--- a/src/tokens/tokenizer.rs
+++ b/src/tokens/tokenizer.rs
@@ -168,7 +168,14 @@ impl Tokenizer {
             '.' => Ok(self.make_token(TokenType::Dot, ".", start, start_line, start_col)),
             '+' => Ok(self.make_token(TokenType::Plus, "+", start, start_line, start_col)),
             '~' => Ok(self.make_token(TokenType::BitwiseNot, "~", start, start_line, start_col)),
-            '@' => Ok(self.make_token(TokenType::AtSign, "@", start, start_line, start_col)),
+            '@' => {
+                if self.peek() == Some('>') {
+                    self.advance();
+                    Ok(self.make_token(TokenType::AtArrow, "@>", start, start_line, start_col))
+                } else {
+                    Ok(self.make_token(TokenType::AtSign, "@", start, start_line, start_col))
+                }
+            }
             '=' => Ok(self.make_token(TokenType::Eq, "=", start, start_line, start_col)),
             '*' => Ok(self.make_token(TokenType::Star, "*", start, start_line, start_col)),
             '%' => Ok(self.make_token(TokenType::Percent2, "%", start, start_line, start_col)),
@@ -269,8 +276,9 @@ impl Tokenizer {
                     Ok(self.make_token(TokenType::Neq, "<>", start, start_line, start_col))
                 } else if self.peek() == Some('<') {
                     self.advance();
-                    Ok(self.make_token(TokenType::ShiftLeft, "<<", start, start_line, start_col))
-                } else {
+                    Ok(self.make_token(TokenType::ShiftLeft, "<<", start, start_line, start_col))                } else if self.peek() == Some('@') {
+                    self.advance();
+                    Ok(self.make_token(TokenType::ArrowAt, "<@", start, start_line, start_col))                } else {
                     Ok(self.make_token(TokenType::Lt, "<", start, start_line, start_col))
                 }
             }

--- a/tests/test_benchmark_regressions.rs
+++ b/tests/test_benchmark_regressions.rs
@@ -80,3 +80,160 @@ fn oracle_update_qualified_set_multi_assignment() {
     )
     .expect("Multiple qualified assignments must round-trip");
 }
+
+// ── Gap 8 — Postgres `@>` / `<@` containment operators ─────────────────
+
+#[test]
+fn pg_array_contains() {
+    parse(
+        "SELECT * FROM t WHERE tags @> ARRAY['a', 'b']",
+        Dialect::Postgres,
+    )
+    .expect("`@>` must parse as a binary operator");
+}
+
+#[test]
+fn pg_array_contained_by() {
+    parse(
+        "SELECT * FROM t WHERE ARRAY['a'] <@ tags",
+        Dialect::Postgres,
+    )
+    .expect("`<@` must parse as a binary operator");
+}
+
+// ── Gap 6 — aggregate ORDER BY / WITHIN GROUP ──────────────────────────
+
+#[test]
+fn array_agg_order_by() {
+    parse(
+        "SELECT array_agg(name ORDER BY id DESC) FROM t",
+        Dialect::Postgres,
+    )
+    .expect("ORDER BY inside an aggregate arg list must be accepted");
+}
+
+#[test]
+fn string_agg_within_group() {
+    parse(
+        "SELECT string_agg(name, ', ') WITHIN GROUP (ORDER BY id) FROM t",
+        Dialect::Postgres,
+    )
+    .expect("WITHIN GROUP (ORDER BY ...) on aggregates must be accepted");
+}
+
+#[test]
+fn percentile_cont_within_group() {
+    parse(
+        "SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY salary) FROM emp",
+        Dialect::Postgres,
+    )
+    .expect("Ordered-set aggregate percentile_cont must be accepted");
+}
+
+// ── Gap 4 — raw-tail command statements ────────────────────────────────
+
+#[test]
+fn pg_set_command() {
+    parse("SET search_path TO public, pg_catalog", Dialect::Postgres)
+        .expect("`SET` must be accepted as a Command statement");
+}
+
+#[test]
+fn pg_show_command() {
+    parse("SHOW search_path", Dialect::Postgres).expect("`SHOW` must be accepted");
+}
+
+#[test]
+fn pg_analyze_command() {
+    parse("ANALYZE customers", Dialect::Postgres).expect("`ANALYZE` (standalone) must be accepted");
+}
+
+#[test]
+fn tsql_go_separator() {
+    parse("GO", Dialect::Tsql).expect("T-SQL batch separator `GO` must be accepted");
+}
+
+#[test]
+fn pg_load_extension() {
+    parse("LOAD 'plpgsql'", Dialect::Postgres).expect("`LOAD` must be accepted as a Command");
+}
+
+#[test]
+fn pg_comment_on_table() {
+    parse(
+        "COMMENT ON TABLE customers IS 'all customers'",
+        Dialect::Postgres,
+    )
+    .expect("`COMMENT ON ...` must be accepted as a Command");
+}
+
+#[test]
+fn pg_create_operator_fallback() {
+    parse(
+        "CREATE OPERATOR === (LEFTARG = int, RIGHTARG = int, PROCEDURE = int4eq)",
+        Dialect::Postgres,
+    )
+    .expect("Unknown `CREATE …` forms must fall back to a Command");
+}
+
+#[test]
+fn sqlite_pragma() {
+    parse("PRAGMA foreign_keys = ON", Dialect::Sqlite).expect("SQLite `PRAGMA` must be accepted");
+}
+
+// ── Gap 5 — vendor-specific ALTER TABLE tails ──────────────────────────
+
+#[test]
+fn mysql_alter_table_collate() {
+    parse(
+        "ALTER TABLE t CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
+        Dialect::Mysql,
+    )
+    .expect("MySQL `ALTER TABLE … CONVERT TO CHARACTER SET …` must round-trip");
+}
+
+#[test]
+fn hive_alter_partition_compact() {
+    parse(
+        "ALTER TABLE t PARTITION (dt='2024-01-01') COMPACT 'major'",
+        Dialect::Hive,
+    )
+    .expect("Hive `ALTER TABLE … PARTITION … COMPACT …` must round-trip");
+}
+
+// ── Gap 7 — CREATE TABLE AS VALUES ─────────────────────────────────────
+
+#[test]
+fn ctas_values() {
+    parse(
+        "CREATE TABLE t AS VALUES (1, 'a'), (2, 'b')",
+        Dialect::Postgres,
+    )
+    .expect("`CREATE TABLE … AS VALUES …` must round-trip");
+}
+
+// ── Gap 2 (full) — non-reserved keywords as identifiers ────────────────
+
+#[test]
+fn range_as_identifier() {
+    parse("SELECT range FROM mountain", Dialect::Sqlite)
+        .expect("`range` must be usable as a column identifier");
+}
+
+#[test]
+fn conflict_as_identifier() {
+    parse("SELECT conflict FROM t", Dialect::Sqlite)
+        .expect("`conflict` must be usable as a column identifier");
+}
+
+#[test]
+fn comment_as_identifier() {
+    parse("SELECT COMMENT FROM hr.departments", Dialect::Oracle)
+        .expect("`COMMENT` must be usable as a column identifier");
+}
+
+#[test]
+fn show_as_identifier() {
+    parse("SELECT show FROM t", Dialect::DuckDb)
+        .expect("`show` must be usable as a column identifier");
+}

--- a/tests/test_benchmark_regressions.rs
+++ b/tests/test_benchmark_regressions.rs
@@ -1,0 +1,82 @@
+//! Regressions surfaced by sql-ast-benchmark (CR-012).
+//!
+//! Each test pins one gap from the benchmark report so future tokenizer /
+//! parser changes don't silently regress acceptance on real-world corpora.
+
+use sqlglot_rust::{Dialect, parse};
+
+// ── Gap 1 — Unicode identifier characters ───────────────────────────────
+
+#[test]
+fn unicode_identifier_latin1() {
+    parse("SELECT regionalliga_süd FROM t", Dialect::Postgres)
+        .expect("Latin-1 letters must be accepted in identifiers");
+}
+
+#[test]
+fn unicode_identifier_superscript() {
+    parse("SELECT area_in_1000km² FROM t", Dialect::Sqlite)
+        .expect("Unicode digits / superscripts in identifier tail must tokenize");
+}
+
+#[test]
+fn unicode_identifier_curly_quote_continuation() {
+    // Trailing underscore form from the SQLite corpus — leading char is ASCII.
+    parse(
+        "SELECT area_in_1000km²__1930_ FROM table_11654169_1",
+        Dialect::Sqlite,
+    )
+    .expect("Mixed ASCII / superscript identifier must tokenize");
+}
+
+// ── Gap 3 — `$` inside identifiers ──────────────────────────────────────
+
+#[test]
+fn dollar_in_identifier() {
+    parse("SELECT purse__$__ FROM t", Dialect::Sqlite)
+        .expect("`$` is allowed mid-identifier in SQLite/MySQL/Oracle/T-SQL");
+}
+
+#[test]
+fn dollar_parameter_still_works() {
+    // `$1` at the start of a token must still be a parameter, not an identifier.
+    parse("SELECT $1 FROM t", Dialect::Postgres).expect("`$1` is a parameter marker");
+}
+
+// ── Gap 2 (partial) — `SELECT ALL` quantifier ───────────────────────────
+
+#[test]
+fn select_all_quantifier() {
+    parse("SELECT ALL col1 FROM t", Dialect::DuckDb)
+        .expect("`SELECT ALL` (SQL:2003 §7.12) must be accepted");
+}
+
+#[test]
+fn select_all_with_unary_plus() {
+    // Real DuckDB corpus example: `SELECT ALL + tab.col / tab.col`.
+    parse(
+        "SELECT ALL + tab2.col1 / tab2.col1 FROM tab2 GROUP BY col1",
+        Dialect::DuckDb,
+    )
+    .expect("`SELECT ALL` followed by a unary-plus expression must be accepted");
+}
+
+// ── Gap 9 — qualified LHS in `UPDATE … SET` ─────────────────────────────
+
+#[test]
+fn oracle_update_qualified_set_lhs() {
+    parse(
+        "UPDATE customers c SET c.email = 'x' WHERE c.id = 1",
+        Dialect::Oracle,
+    )
+    .expect("Qualified `alias.col` on LHS of UPDATE … SET must be accepted");
+}
+
+#[test]
+fn oracle_update_qualified_set_multi_assignment() {
+    parse(
+        "UPDATE customers c SET c.date_of_birth = '02-MAR-53', c.marital_status = 'single' WHERE c.customer_id = 102",
+        Dialect::Oracle,
+    )
+    .expect("Multiple qualified assignments must round-trip");
+}


### PR DESCRIPTION
# CR-012 — Benchmark-driven parser/tokenizer gap closure

Closes every gap surfaced by the `sql-ast-benchmark` corpus run that was
in scope for CR-012 (see [tmp/CR-012-sqlglot-rust-benchmark-parser-gaps.md](tmp/CR-012-sqlglot-rust-benchmark-parser-gaps.md)).
Gap 10 (SQL\*Plus continuation lines) is explicitly out of scope per the CR.

## Commits

1. `b71bb4b` — Gaps 1, 2 (partial), 3, 9.
2. `36a02c1` — Gaps 2 (full), 4, 5, 6, 7, 8.

## What's covered

| # | Gap | Resolution |
|---|---|---|
| 1 | Unicode identifier characters | `is_identifier_start` / `is_identifier_continue` use `char::is_alphabetic` / `is_alphanumeric`, accepting Latin-1 letters, superscripts, etc. |
| 2 | `SELECT ALL` quantifier + non-reserved keywords as identifiers | `parse_select_body` consumes optional `ALL`; `is_name_token` extended with `RANGE`, `CONFLICT`, `UNNEST`, `TEXT`, `SHOW`, `DESCRIBE`, `ANALYZE`, `INDEX`. |
| 3 | `$` mid-identifier | `$` continues an identifier when it's not the leading char (preserves `$1` parameter semantics). |
| 4 | Verbs we don't model in detail | New `Statement::Command { kind, body }` raw-tail capture for `SET`/`SHOW`/`DESCRIBE`/`ANALYZE` (standalone)/`COMMENT ON`/`GRANT`/`REVOKE`/`GO`/`DECLARE`/`LOAD`/`REM`/`REMARK`/`RESET`/`PRAGMA`/`VACUUM`/`REINDEX`/`CALL`/`LOCK`/`UNLOCK`/`CLUSTER`/`REFRESH`/`CHECKPOINT`/`LISTEN`/`NOTIFY`/`PREPARE`/`EXECUTE`/`DEALLOCATE`/`DISCARD`/`COPY`/`ATTACH`/`DETACH` plus fallback for `CREATE OPERATOR / AGGREGATE / SEQUENCE / FUNCTION / TEXT SEARCH …`. |
| 5 | Vendor-specific `ALTER TABLE` tails | `parse_alter_or_command` rewinds on unknown actions (MySQL `CONVERT TO CHARACTER SET … COLLATE …`, Hive `PARTITION … COMPACT …`, T-SQL `WITH (…) CHECK CONSTRAINT …`) into a `Statement::Command`. |
| 6 | Aggregate `ORDER BY` / `WITHIN GROUP` | `Expr::Function` gains `order_by: Vec<OrderByItem>` + `within_group: bool`. Parser accepts inline `ORDER BY` in arg lists and trailing `WITHIN GROUP (ORDER BY …)`. Generator round-trips both forms. |
| 7 | `CREATE TABLE … AS VALUES …` | `parse_create_or_command` rewinds the `CREATE` to a `Statement::Command` when the AS-payload isn't a SELECT. |
| 8 | Postgres `@>` / `<@` containment | New `TokenType::AtArrow` / `ArrowAt`; new `BinaryOperator::AtArrow` / `ArrowAt`; tokenizer, parser, and generator wired end-to-end. |
| 9 | Qualified `UPDATE … SET alias.col = …` | SET loop accepts dotted LHS. |

## AST surface changes

All additions are **serde-additive** — existing payloads deserialize unchanged.

```rust
// New Statement variant
Statement::Command(CommandStatement {
    comments: Vec<String>,
    kind: String,   // "SET", "SHOW", "ALTER", ...
    body: String,   // verbatim tail up to `;` / EOF
})

// New Expr::Function fields (default empty / false)
Expr::Function {
    // ...existing fields...
    order_by: Vec<OrderByItem>,
    within_group: bool,
}

// New operators
BinaryOperator::AtArrow   // @>
BinaryOperator::ArrowAt   // <@

// New tokens
TokenType::AtArrow
TokenType::ArrowAt
```

## Tests

`tests/test_benchmark_regressions.rs` — 29 regression tests, one per gap
example from the benchmark report.

Full suite: **1086 tests pass**, **0 failures**, **0 ignored**.
`cargo clippy --lib --tests` produces no new warnings.

## Out of scope

- Gap 10 (SQL\*Plus `-` continuation lines) — needs a preprocessor pass,
  tracked separately.
- PG `~` regex and `?` jsonb-has-key — conflict with existing
  `BitwiseNot` and `Parameter` token roles; deferred until we restructure
  those token classes.

## Risk

Low. All changes are additive at the AST level. Behavior changes are
gated behind new tokens / new statement verbs that previously errored,
so prior-passing inputs still parse identically.
