### PR TITLE
fix(parser): accept string literal aliases after AS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sqlglot-rust"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlglot-rust"
-version = "0.10.10"
+version = "0.10.11"
 edition = "2024"
 description = "A SQL parser, optimizer, and transpiler library inspired by Python's sqlglot"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sqlglot-rust = "0.10.10"
+sqlglot-rust = "0.10.11"
 ```
 
 ### Parse and generate SQL

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ Add `sqlglot-rust` to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-sqlglot-rust = "0.10.10"
+sqlglot-rust = "0.10.11"
 ```
 
 Then run:

--- a/src/parser/sql_parser.rs
+++ b/src/parser/sql_parser.rs
@@ -2234,6 +2234,14 @@ impl Parser {
                 let token = self.advance().clone();
                 return Ok(Some((token.value, QuoteStyle::None)));
             }
+            // SQLite / MySQL / Snowflake accept a string literal as an alias
+            // (`AS 'Record Id'`). The alias is an identifier despite the
+            // quoting, so normalize to DoubleQuote. Only after an explicit AS -
+            // an implicit trailing string is concatenation in MySQL.
+            if matches!(self.peek_type(), TokenType::String) {
+                let token = self.advance().clone();
+                return Ok(Some((token.value, QuoteStyle::DoubleQuote)));
+            }
             return Ok(Some(self.expect_name_with_quote()?));
         }
         // Implicit alias

--- a/tests/test_quoted_aliases.rs
+++ b/tests/test_quoted_aliases.rs
@@ -164,3 +164,55 @@ fn test_implicit_quoted_alias() {
         Dialect::Postgres,
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Single-quoted (string literal) alias - SQLite / MySQL / Snowflake
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_single_quoted_column_alias_normalizes_to_double() {
+    validate(
+        r#"SELECT record_id AS 'Record Id' FROM deals"#,
+        r#"SELECT record_id AS "Record Id" FROM deals"#,
+        Dialect::Sqlite,
+    );
+}
+
+#[test]
+fn test_single_quoted_table_alias_normalizes_to_double() {
+    validate(
+        r#"SELECT a FROM deals AS 't'"#,
+        r#"SELECT a FROM deals AS "t""#,
+        Dialect::Sqlite,
+    );
+}
+
+#[test]
+fn test_single_quoted_alias_with_quoted_column_ref() {
+    validate(
+        r#"SELECT "deals"."record_id" AS 'Record Id' FROM "deals""#,
+        r#"SELECT "deals"."record_id" AS "Record Id" FROM "deals""#,
+        Dialect::Sqlite,
+    );
+}
+
+#[test]
+fn test_single_quoted_alias_with_escaped_quote() {
+    validate(
+        r#"SELECT 1 AS 'It''s'"#,
+        r#"SELECT 1 AS "It's""#,
+        Dialect::Sqlite,
+    );
+}
+
+#[test]
+fn test_single_quoted_alias_transpile_to_mysql() {
+    let result = transpile(r#"SELECT 7 AS 'Mixed'"#, Dialect::Sqlite, Dialect::Mysql).unwrap();
+    assert_eq!(result, "SELECT 7 AS `Mixed`");
+}
+
+#[test]
+fn test_string_literal_expression_not_treated_as_alias() {
+    // A trailing string with no AS stays a string expression, never an alias.
+    validate_identity(r#"SELECT 'a', 'b' FROM t"#, Dialect::Sqlite);
+}


### PR DESCRIPTION
## Problem

SQLite, MySQL, and Snowflake accept a string literal as a column or table
alias, but the parser rejects it:

```sh
$ echo "select \"deals\".\"record_id\" as 'Record Id', sum(amount) from \"deals\" group by 1" \
    | sqlglot format --read sqlite

# Before (v0.10.9, unpatched):

error: Parser error: Expected identifier, got String ('Record Id') at line 1 col 31

# After:

SELECT
  "deals"."record_id" AS "Record Id",
  SUM(amount)
FROM
  "deals"
GROUP BY
  1
```

This form is common in machine-generated SQL (e.g. ORMs that quote
display-name aliases as string literals).

## Fix

parse_optional_alias now accepts a String token in alias position after
an explicit AS, for both column and table aliases. The alias is an
identifier despite the quoting, so it is normalized to
`QuoteStyle::DoubleQuote` and the generator re-quotes it in each target
dialect's canonical style:

```sql
-- SQLite/Postgres:  SELECT record_id AS "Record Id" FROM deals
-- MySQL:            SELECT record_id AS `Record Id` FROM deals
-- T-SQL:            SELECT record_id AS [Record Id] FROM deals
```

The implicit form (no AS, e.g. SELECT 'a' 'b') is intentionally not
accepted — adjacent string literals are concatenation in MySQL, so treating
a trailing string as an alias would silently change semantics.

Escaped quotes in the literal are handled by the tokenizer as usual
(AS 'It''s' → AS "It's").

## Tests

Six new tests in tests/test_quoted_aliases.rs: column alias, table alias,
alias alongside quoted column refs, escaped inner quote, SQLite→MySQL
transpile, and a regression guard that a trailing string without AS
remains a string expression.