### PR TITLE
docs(reference): document string-literal alias support (follow-up to #22)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1218,6 +1218,31 @@ assert!(QuoteStyle::Backtick.is_quoted());
 assert!(!QuoteStyle::None.is_quoted());
 ```
 
+### String-Literal Aliases
+
+Some dialects accept a **string literal** as an alias after an explicit `AS`
+(`SELECT col AS 'Record Id'`) — notably SQLite, MySQL, Snowflake, and T-SQL
+(legacy syntax). The parser accepts this form for every dialect (it is lenient
+on input) and normalizes the alias to a **quoted identifier**, so the generator
+re-emits it in the target dialect's canonical quote style with embedded quotes
+escaped. The alias is treated as quoted, so its case is always preserved
+(never folded).
+
+```rust
+use sqlglot_rust::{transpile, Dialect};
+
+// SQLite string-literal alias → the target dialect's canonical quoted identifier
+assert_eq!(transpile("SELECT 7 AS 'Mixed'", Dialect::Sqlite, Dialect::Postgres).unwrap(),
+           r#"SELECT 7 AS "Mixed""#);   // double quote
+assert_eq!(transpile("SELECT 7 AS 'Mixed'", Dialect::Sqlite, Dialect::Mysql).unwrap(),
+           "SELECT 7 AS `Mixed`");      // backtick
+assert_eq!(transpile("SELECT 7 AS 'Mixed'", Dialect::Sqlite, Dialect::Tsql).unwrap(),
+           "SELECT 7 AS [Mixed]");      // bracket
+```
+
+> A trailing string with **no** `AS` is never treated as an alias (in MySQL,
+> adjacent string literals are concatenation).
+
 ---
 
 ## Dialect Enum


### PR DESCRIPTION
## Documentation follow-up to #22 (string-literal aliases, released in `v0.10.11`)

Follows up on @gauravs's PR #22, which added support for string-literal aliases
after `AS` (`SELECT col AS 'Record Id'`). The parser + test changes are already
merged and shipped in **`v0.10.11`**; this PR is **docs-only**.

### What's here

- **`docs/reference.md`** — adds a **String-Literal Aliases** subsection under
  the `QuoteStyle` reference documenting that `AS 'x'` is accepted for every
  dialect (lenient on input) and normalized to the target dialect's canonical
  quoted identifier — `"x"` (double-quote), `` `x` `` (backtick), or `[x]`
  (bracket) — with case preserved and embedded quotes escaped.
- The three transpile examples are the **exact outputs asserted** by the
  `test_single_quoted_alias_transpile_to_{postgres,mysql,tsql}` tests, so they
  stay accurate.

### Note on the CR-022 record

Per this repo's convention, the detailed change-record (`CR-022`) lives as a
**local `tmp/` working note** (the `tmp/` directory is gitignored and none of
the CR-003…CR-021 docs are tracked either), so it is intentionally **not**
included in this PR. Happy to relocate it into a tracked path if you'd prefer
CR records to be version-controlled going forward.

### Scope

Docs only — no code or behavior changes. The feature itself is already released.
